### PR TITLE
[BE] 미션 매핑 방식 수정

### DIFF
--- a/back/dubeng-user/src/main/java/com/ssafy/dubenguser/controller/MissionController.java
+++ b/back/dubeng-user/src/main/java/com/ssafy/dubenguser/controller/MissionController.java
@@ -1,16 +1,13 @@
 package com.ssafy.dubenguser.controller;
 
-import com.ssafy.dubenguser.config.CookieHandler;
+
 import com.ssafy.dubenguser.dto.UserMissionRes;
-import com.ssafy.dubenguser.entity.User;
-import com.ssafy.dubenguser.exception.UnAuthorizedException;
+import com.ssafy.dubenguser.entity.UserMission;
 import com.ssafy.dubenguser.service.UserMissionService;
-import com.ssafy.dubenguser.service.UserMissionServiceImpl;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
@@ -18,7 +15,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.servlet.http.HttpServletRequest;
 import java.util.HashMap;
 import java.util.List;
-import java.util.Objects;
 
 @Slf4j
 @RestController
@@ -28,7 +24,7 @@ import java.util.Objects;
 public class MissionController {
     private final UserMissionService userMissionService;
 
-    @ApiOperation(value="도전과제 미션 목록 조회")
+    @ApiOperation(value="해결한 도전과제 미션 목록 조회")
     @GetMapping("/list")
     public ResponseEntity<List<UserMissionRes>> userMissionList(HttpServletRequest request){
         String accessToken = (String) request.getAttribute("Authorization");

--- a/back/dubeng-user/src/main/java/com/ssafy/dubenguser/dto/UserMissionRes.java
+++ b/back/dubeng-user/src/main/java/com/ssafy/dubenguser/dto/UserMissionRes.java
@@ -1,15 +1,17 @@
 package com.ssafy.dubenguser.dto;
 
+import com.ssafy.dubenguser.entity.Video;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
+@NoArgsConstructor
 @AllArgsConstructor
 public class UserMissionRes {
-    Long videoId;
-    String title; // 미션 이름
-    String assets; // 에셋 내용
-    String color; // 미션 고유 컬러
-    Boolean isComplete; // 완료 여부
-
+    private String title; // 미션 이름
+    private String assets; // 에셋 내용
+    private String color; // 미션 고유 컬러
+    private Long videoId;
+    private boolean isActive;
 }

--- a/back/dubeng-user/src/main/java/com/ssafy/dubenguser/entity/Mission.java
+++ b/back/dubeng-user/src/main/java/com/ssafy/dubenguser/entity/Mission.java
@@ -10,7 +10,7 @@ import javax.persistence.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "mission")
-public class Mission extends Time{
+public class Mission{
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -18,9 +18,4 @@ public class Mission extends Time{
     private String title;
     private String assets;
     private String color;
-
-    @OneToOne(cascade = CascadeType.MERGE, targetEntity = Video.class, fetch = FetchType.LAZY)
-    @JoinColumn(name="video_id")
-    private Video video;
-
 }

--- a/back/dubeng-user/src/main/java/com/ssafy/dubenguser/entity/VideoMission.java
+++ b/back/dubeng-user/src/main/java/com/ssafy/dubenguser/entity/VideoMission.java
@@ -1,33 +1,25 @@
 package com.ssafy.dubenguser.entity;
 
 import lombok.AccessLevel;
-import lombok.Builder;
-import lombok.Getter;
+import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+@Data
 @Entity
-@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "user_mission")
-public class UserMission extends Time{
-
+@Table(name = "video_mission")
+public class VideoMission {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-    @ManyToOne(cascade = CascadeType.MERGE, targetEntity = User.class, fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
-    private User user;
+
+    @ManyToOne(cascade = CascadeType.MERGE, targetEntity = Video.class, fetch = FetchType.LAZY)
+    @JoinColumn(name = "video_id")
+    private Video video;
 
     @ManyToOne(cascade = CascadeType.MERGE, targetEntity = Mission.class, fetch = FetchType.LAZY)
     @JoinColumn(name = "mission_id")
     private Mission mission;
-
-    @Builder
-    public UserMission(Long id, User user, Mission mission) {
-        this.id = id;
-        this.user = user;
-        this.mission = mission;
-    }
 }

--- a/back/dubeng-user/src/main/java/com/ssafy/dubenguser/repository/MissionRepository.java
+++ b/back/dubeng-user/src/main/java/com/ssafy/dubenguser/repository/MissionRepository.java
@@ -9,5 +9,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.Optional;
 
 public interface MissionRepository extends JpaRepository<Mission, Long> {
-    public Optional<Mission> findByVideoId(Long videoId);
+
 }

--- a/back/dubeng-user/src/main/java/com/ssafy/dubenguser/repository/UserMissionRepository.java
+++ b/back/dubeng-user/src/main/java/com/ssafy/dubenguser/repository/UserMissionRepository.java
@@ -1,6 +1,7 @@
 package com.ssafy.dubenguser.repository;
 
 import com.ssafy.dubenguser.dto.UserMissionRes;
+import com.ssafy.dubenguser.entity.Mission;
 import com.ssafy.dubenguser.entity.User;
 import com.ssafy.dubenguser.entity.UserMission;
 import com.ssafy.dubenguser.entity.Video;
@@ -12,18 +13,22 @@ import java.util.Optional;
 
 public interface UserMissionRepository extends JpaRepository<UserMission, Long> {
 
-    @Query("select new com.ssafy.dubenguser.dto.UserMissionRes(m.video.id, m.title, m.assets, m.color, um.isComplete)" +
+    @Query("select distinct um.mission.id" +
             " from UserMission um " +
-            "left join Mission m on m.id = um.mission.id" +
             " where um.user=:user")
-    public List<UserMissionRes> findUserMissionsByUser(User user);
+    public List<Long> findUserMissionsByUser(User user);
 
     @Query("select m.assets" +
             " from UserMission um " +
             "left join Mission m on m.id = um.mission.id" +
-            " where um.user=:user and um.isComplete=true")
+            " where um.user=:user")
     public List<String> findAssetsByUser(User user);
-    @Query("select um from UserMission um where um.user=:user and um.mission.video=:video")
-    public Optional<UserMission> findByUserAndVideo(User user, Video video);
+
+//    @Query("select um from UserMission um where um.user=:user and um.mission.video=:video")
+//    public Optional<UserMission> findByUserAndVideo(User user, Video video);
+    @Query("select um" +
+            " from UserMission um" +
+            " where um.user=:user and um.mission=:mission")
+    public Optional<UserMission> findByUserAndVideo(User user, Mission mission);
 
 }

--- a/back/dubeng-user/src/main/java/com/ssafy/dubenguser/repository/VideoMissionRepository.java
+++ b/back/dubeng-user/src/main/java/com/ssafy/dubenguser/repository/VideoMissionRepository.java
@@ -1,0 +1,17 @@
+package com.ssafy.dubenguser.repository;
+
+import com.ssafy.dubenguser.entity.Mission;
+import com.ssafy.dubenguser.entity.Video;
+import com.ssafy.dubenguser.entity.VideoMission;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.Optional;
+
+public interface VideoMissionRepository extends JpaRepository<VideoMission, Long> {
+
+    @Query("select vm.mission" +
+            " from VideoMission vm " +
+            " where vm.video=:video")
+    public Optional<Mission> findVideoMissionByVideo(Video video);
+}

--- a/back/dubeng-user/src/main/java/com/ssafy/dubenguser/service/UserMissionService.java
+++ b/back/dubeng-user/src/main/java/com/ssafy/dubenguser/service/UserMissionService.java
@@ -1,10 +1,10 @@
 package com.ssafy.dubenguser.service;
 
 import com.ssafy.dubenguser.dto.UserMissionRes;
+import com.ssafy.dubenguser.entity.UserMission;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Objects;
 
 public interface UserMissionService {
 

--- a/back/dubeng-user/src/main/java/com/ssafy/dubenguser/service/UserMissionServiceImpl.java
+++ b/back/dubeng-user/src/main/java/com/ssafy/dubenguser/service/UserMissionServiceImpl.java
@@ -5,15 +5,13 @@ import com.ssafy.dubenguser.dto.UserMissionRes;
 import com.ssafy.dubenguser.entity.*;
 import com.ssafy.dubenguser.exception.NotFoundException;
 import com.ssafy.dubenguser.exception.UnAuthorizedException;
-import com.ssafy.dubenguser.repository.MissionRepository;
-import com.ssafy.dubenguser.repository.UserMissionRepository;
-import com.ssafy.dubenguser.repository.UserRepository;
-import com.ssafy.dubenguser.repository.VideoRepository;
+import com.ssafy.dubenguser.repository.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
@@ -25,11 +23,15 @@ public class UserMissionServiceImpl implements UserMissionService{
     private final AuthService authService;
     private final UserRepository userRepository;
     private final UserMissionRepository userMissionRepository;
+    private final VideoMissionRepository videoMissionRepository;
     private final VideoRepository videoRepository;
     private final MissionRepository missionRepository;
     private String unAuthorizedException = "토큰 파싱과정에서 오류";
     private String noUser = "존재하지 않는 유저입니다!";
 
+    /**
+     *  클리어한 도전과제 리스트 뽑기
+     */
     @Override
     public List<UserMissionRes> findUserMissions(String accessToken) {
         String userId = authService.parseToken(accessToken);
@@ -40,9 +42,21 @@ public class UserMissionServiceImpl implements UserMissionService{
         if(!user.isPresent()) {
             throw new NotFoundException(noUser);
         }
+        //미션 리스트 가져오기
+        List<Mission> missionList = missionRepository.findAll();
+        
+        //사용자가 깬 도전과제 목록
+        List<Long> list = userMissionRepository.findUserMissionsByUser(user.get());
 
-        List<UserMissionRes> result = userMissionRepository.findUserMissionsByUser(user.get());
-        return  result;
+        List<UserMissionRes> result = new ArrayList<>();
+        for(Mission mission : missionList) {
+            System.out.println(mission.getId());
+            UserMissionRes userMissionRes = new UserMissionRes(mission.getTitle(), mission.getAssets(), mission.getColor(), mission.getId(), true);
+
+            if(!list.contains(mission.getId())) userMissionRes.setActive(false);
+            result.add(userMissionRes);
+        }
+        return result;
     }
 
     @Override
@@ -76,23 +90,23 @@ public class UserMissionServiceImpl implements UserMissionService{
         if(!video.isPresent()) {
             throw new NotFoundException("존재하지 않는 비디오입니다!");
         }
-        Optional<Mission> omission = missionRepository.findByVideoId(videoId);
-        if(!omission.isPresent()){
-            throw new NotFoundException("미션이 없습니다!");
-        }
+//        Optional<Mission> omission = missionRepository.findById(videoId);
+//        if(!omission.isPresent()){
+//            throw new NotFoundException("미션이 없습니다!");
+//        }
+        //비디오에 매핑되어 있는 미션 찾기
+        Optional<Mission> findMission = videoMissionRepository.findVideoMissionByVideo(video.get());
+        Mission mission = findMission.get();
+
         // 이미 완료 되었는지 확인
-        Optional<UserMission> ouserMission = userMissionRepository.findByUserAndVideo(user.get(), video.get());
-        if(!ouserMission.isPresent()){
-            throw new NotFoundException("user mission 없습니다!");
-        }
-        UserMission userMission = ouserMission.get();
+        Optional<UserMission> ouserMission = userMissionRepository.findByUserAndVideo(user.get(), mission);
+
         HashMap<String, Object> result = new HashMap<>();
-        if(userMission.getIsComplete()){ // 이미 완료 되었다
+        if(ouserMission.isPresent()){ // 이미 완료 되었다
             result.put("message", "이미 완료된 미션입니다.");
             result.put("code",204);
         }else{
-            Mission mission = omission.get();
-            userMission.updateUserMissionComplete();
+            UserMission userMission = UserMission.builder().user(user.get()).mission(mission).build();
             userMissionRepository.save(userMission);
             result.put("message", "미션을 완료했습니다.");
             result.put("code",200);

--- a/back/dubeng-user/src/main/resources/application.yml
+++ b/back/dubeng-user/src/main/resources/application.yml
@@ -29,6 +29,7 @@ logging:
     root: info
     com:
       ssafy: debug
+    org.hibernate.sql: debug
 
 
 


### PR DESCRIPTION
[기존 방식]

회원가입시 유저마다 클리어되지 않은 10개의 도전과제를 DB에 입력시켜놓는다.

[문제점]

도전과제를 생성할 때 마다 회원 - 도전과제 테이블에 회원별 컬럼을 하나씩 추가해야 한다.

도전과제 클리어 시 DB에 update문 사용

[ 설계 ]

영상을 추가할 때마다 1:N개의 도전과제를 매핑 (video - mission)

결국, 1개의 영상은 여러 개의 mission을 가질 수 있고 mission 또한 여러 개의 영상을 가질 수 있다.

회원 - 도전과제 테이블에는 클리어한 도전과제만 insert